### PR TITLE
feat(#14): Change lockfile behavior

### DIFF
--- a/misc/generals.go
+++ b/misc/generals.go
@@ -133,9 +133,9 @@ func GetMessage(n logger.LogRecord, project, server string) (m string) {
 	case logrus.InfoLevel:
 		m += "[INFO]\n\n"
 	case logrus.WarnLevel:
-		m += "⚠️[WARNING]\n\n"
+		m += "⚠️[WARNING]⚠️\n\n"
 	case logrus.ErrorLevel:
-		m += "‼️[ERROR]\n\n"
+		m += "‼️[ERROR]‼️\n\n"
 	case logrus.PanicLevel:
 	case logrus.FatalLevel:
 	case logrus.TraceLevel:


### PR DESCRIPTION
- lockfile is used only for performing backups
- self-updating, config generation and validation are performed without locking
- added notification of a startup error event if another nxs-backup process is already running