### PR TITLE
fix[#36]: backup rotation fix

### DIFF
--- a/modules/backup/backup.go
+++ b/modules/backup/backup.go
@@ -17,6 +17,11 @@ func Perform(logCh chan logger.LogRecord, job interfaces.Job) error {
 	var errs *multierror.Error
 	var tmpDirPath string
 
+	if !job.NeedToMakeBackup() {
+		logCh <- logger.Log(job.GetName(), "").Infof("According to the backup plan today new backups are not created for job %s", job.GetName())
+		return nil
+	}
+
 	if job.GetStoragesCount() == 0 {
 		logCh <- logger.Log(job.GetName(), "").Warn("There are no configured storages for job.")
 		return nil
@@ -26,11 +31,6 @@ func Perform(logCh chan logger.LogRecord, job interfaces.Job) error {
 		if err := job.DeleteOldBackups(logCh, ""); err != nil {
 			errs = multierror.Append(errs, err)
 		}
-	}
-
-	if !job.NeedToMakeBackup() {
-		logCh <- logger.Log(job.GetName(), "").Infof("According to the backup plan today new backups are not created for job %s", job.GetName())
-		return nil
 	}
 
 	logCh <- logger.Log(job.GetName(), "").Info("Starting")

--- a/modules/storage/ftp/ftp.go
+++ b/modules/storage/ftp/ftp.go
@@ -173,16 +173,19 @@ func (f *FTP) deleteDescBackup(logCh chan logger.LogRecord, job, ofsPart string,
 
 		switch period {
 		case "daily":
+			if f.Retention.Days == 0 {
+				continue
+			}
 			retentionCount = f.Retention.Days
 			retentionDate = curDate.AddDate(0, 0, -f.Retention.Days)
 		case "weekly":
-			if misc.GetDateTimeNow("dow") != misc.WeeklyBackupDay {
+			if misc.GetDateTimeNow("dow") != misc.WeeklyBackupDay || f.Retention.Weeks == 0 {
 				continue
 			}
 			retentionCount = f.Retention.Weeks
 			retentionDate = curDate.AddDate(0, 0, -f.Retention.Weeks*7)
 		case "monthly":
-			if misc.GetDateTimeNow("dom") != misc.MonthlyBackupDay {
+			if misc.GetDateTimeNow("dom") != misc.MonthlyBackupDay || f.Retention.Months == 0 {
 				continue
 			}
 			retentionCount = f.Retention.Months

--- a/modules/storage/local/local.go
+++ b/modules/storage/local/local.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -157,25 +158,34 @@ func (l *Local) DeleteOldBackups(logCh chan logger.LogRecord, ofsPart string, jo
 }
 
 func (l *Local) deleteDescBackup(logCh chan logger.LogRecord, jobName, ofsPart string, safety bool) error {
+	type fileLinks struct {
+		wLink string
+		dLink string
+	}
 	var errs *multierror.Error
+	filesMap := make(map[string]*fileLinks, 64)
+	filesToDeleteMap := make(map[string]*fileLinks, 64)
 	curDate := time.Now().Round(24 * time.Hour)
 
-	for _, period := range []string{"daily", "weekly", "monthly"} {
+	for _, period := range []string{"monthly", "weekly", "daily"} {
 		var retentionDate time.Time
 		retentionCount := 0
 
 		switch period {
 		case "daily":
+			if l.Retention.Days == 0 {
+				continue
+			}
 			retentionCount = l.Retention.Days
 			retentionDate = curDate.AddDate(0, 0, -l.Retention.Days)
 		case "weekly":
-			if misc.GetDateTimeNow("dow") != misc.WeeklyBackupDay {
+			if l.Retention.Weeks == 0 {
 				continue
 			}
 			retentionCount = l.Retention.Weeks
 			retentionDate = curDate.AddDate(0, 0, -l.Retention.Weeks*7)
 		case "monthly":
-			if misc.GetDateTimeNow("dom") != misc.MonthlyBackupDay {
+			if l.Retention.Months == 0 {
 				continue
 			}
 			retentionCount = l.Retention.Months
@@ -198,6 +208,31 @@ func (l *Local) deleteDescBackup(logCh chan logger.LogRecord, jobName, ofsPart s
 		if err != nil {
 			logCh <- logger.Log(jobName, "local").Errorf("Failed to read files in directory '%s' with next error: %s", bakDir, err)
 			return err
+		}
+
+		for _, file := range files {
+			fPath := path.Join(bakDir, file.Name())
+			filesMap[fPath] = &fileLinks{}
+			if file.Type()&fs.ModeSymlink != 0 {
+				link, err := os.Readlink(fPath)
+				if err != nil {
+					logCh <- logger.Log(jobName, "local").Errorf("Failed to read a symlink for file '%s': %s",
+						file, err)
+					errs = multierror.Append(errs, err)
+					continue
+				}
+				linkPath := filepath.Join(bakDir, link)
+
+				if fl, ok := filesMap[linkPath]; ok {
+					switch period {
+					case "weekly":
+						fl.wLink = fPath
+					case "daily":
+						fl.dLink = fPath
+					}
+					filesMap[linkPath] = fl
+				}
+			}
 		}
 
 		if l.Retention.UseCount {
@@ -229,13 +264,59 @@ func (l *Local) deleteDescBackup(logCh chan logger.LogRecord, jobName, ofsPart s
 		}
 
 		for _, file := range files {
-			err = os.Remove(path.Join(bakDir, file.Name()))
-			if err != nil {
-				logCh <- logger.Log(jobName, "local").Errorf("Failed to delete file '%s' in directory '%s' with next error: %s",
-					file.Name(), bakDir, err)
+			fPath := path.Join(bakDir, file.Name())
+			filesToDeleteMap[fPath] = filesMap[fPath]
+		}
+	}
+
+	for file, fl := range filesToDeleteMap {
+		delFile := true
+		moved := false
+		if fl.wLink != "" {
+			if _, toDel := filesToDeleteMap[fl.wLink]; !toDel {
+				delFile = false
+				if err := moveFile(file, fl.wLink); err != nil {
+					logCh <- logger.Log(jobName, "local").Error(err)
+					errs = multierror.Append(errs, err)
+				} else {
+					logCh <- logger.Log(jobName, "local").Debugf("Successfully moved old backup to %s", fl.wLink)
+					moved = true
+				}
+				if _, toDel = filesToDeleteMap[fl.dLink]; !toDel {
+					if err := os.Remove(fl.dLink); err != nil {
+						logCh <- logger.Log(jobName, "local").Error(err)
+						errs = multierror.Append(errs, err)
+						break
+					}
+					relative, _ := filepath.Rel(filepath.Dir(fl.dLink), fl.wLink)
+					if err := os.Symlink(relative, fl.dLink); err != nil {
+						logCh <- logger.Log(jobName, "local").Error(err)
+						errs = multierror.Append(errs, err)
+					} else {
+						logCh <- logger.Log(jobName, "local").Debugf("Successfully changed symlink %s", fl.dLink)
+					}
+				}
+			}
+		}
+		if fl.dLink != "" && !moved {
+			if _, toDel := filesToDeleteMap[fl.dLink]; !toDel {
+				delFile = false
+				if err := moveFile(file, fl.dLink); err != nil {
+					logCh <- logger.Log(jobName, "local").Error(err)
+					errs = multierror.Append(errs, err)
+				} else {
+					logCh <- logger.Log(jobName, "local").Debugf("Successfully moved old backup to %s", fl.dLink)
+				}
+			}
+		}
+
+		if delFile {
+			if err := os.Remove(file); err != nil {
+				logCh <- logger.Log(jobName, "local").Errorf("Failed to delete file '%s' with next error: %s",
+					file, err)
 				errs = multierror.Append(errs, err)
 			} else {
-				logCh <- logger.Log(jobName, "local").Infof("Deleted old backup file '%s' in directory '%s'", file.Name(), bakDir)
+				logCh <- logger.Log(jobName, "local").Infof("Deleted old backup file '%s'", file)
 			}
 		}
 	}
@@ -316,4 +397,14 @@ func (l *Local) Clone() interfaces.Storage {
 
 func (l *Local) GetName() string {
 	return "local"
+}
+
+func moveFile(oldPath, newPath string) error {
+	if err := os.Remove(newPath); err != nil {
+		return fmt.Errorf("Failed to delete file '%s' with next error: %s ", oldPath, err)
+	}
+	if err := os.Rename(oldPath, newPath); err != nil {
+		return fmt.Errorf("Failed to move file '%s' with next error: %s ", oldPath, err)
+	}
+	return nil
 }

--- a/modules/storage/nfs/nfs.go
+++ b/modules/storage/nfs/nfs.go
@@ -169,16 +169,19 @@ func (n *NFS) deleteDescBackup(logCh chan logger.LogRecord, jobName, ofsPart str
 
 		switch period {
 		case "daily":
+			if n.Retention.Days == 0 {
+				continue
+			}
 			retentionCount = n.Retention.Days
 			retentionDate = curDate.AddDate(0, 0, -n.Retention.Days)
 		case "weekly":
-			if misc.GetDateTimeNow("dow") != misc.WeeklyBackupDay {
+			if misc.GetDateTimeNow("dow") != misc.WeeklyBackupDay || n.Retention.Weeks == 0 {
 				continue
 			}
 			retentionCount = n.Retention.Weeks
 			retentionDate = curDate.AddDate(0, 0, -n.Retention.Weeks*7)
 		case "monthly":
-			if misc.GetDateTimeNow("dom") != misc.MonthlyBackupDay {
+			if misc.GetDateTimeNow("dom") != misc.MonthlyBackupDay || n.Retention.Months == 0 {
 				continue
 			}
 			retentionCount = n.Retention.Months

--- a/modules/storage/s3/s3.go
+++ b/modules/storage/s3/s3.go
@@ -173,23 +173,15 @@ func (s *s3) DeleteOldBackups(logCh chan logger.LogRecord, ofs string, job inter
 				}
 			}
 		} else {
-			if strings.Contains(object.Key, "daily") {
+			if strings.Contains(object.Key, "daily") && s.Retention.Days > 0 {
 				if s.Retention.UseCount || object.LastModified.Before(curDate.AddDate(0, 0, -s.Retention.Days)) {
 					filesList["daily"] = append(filesList["daily"], object)
 				}
-			}
-			if strings.Contains(object.Key, "weekly") {
-				if misc.GetDateTimeNow("dow") != misc.WeeklyBackupDay {
-					continue
-				}
+			} else if strings.Contains(object.Key, "weekly") && s.Retention.Weeks > 0 && misc.GetDateTimeNow("dow") == misc.WeeklyBackupDay {
 				if s.Retention.UseCount || object.LastModified.Before(curDate.AddDate(0, 0, -s.Retention.Weeks*7)) {
 					filesList["weekly"] = append(filesList["weekly"], object)
 				}
-			}
-			if strings.Contains(object.Key, "monthly") {
-				if misc.GetDateTimeNow("dom") != misc.MonthlyBackupDay {
-					continue
-				}
+			} else if strings.Contains(object.Key, "monthly") && s.Retention.Weeks > 0 && misc.GetDateTimeNow("dom") == misc.MonthlyBackupDay {
 				if s.Retention.UseCount || object.LastModified.Before(curDate.AddDate(0, -s.Retention.Months, 0)) {
 					filesList["monthly"] = append(filesList["monthly"], object)
 				}

--- a/modules/storage/webdav/wedav.go
+++ b/modules/storage/webdav/wedav.go
@@ -159,16 +159,19 @@ func (wd *webDav) deleteDescBackup(logCh chan logger.LogRecord, jobName, ofsPart
 
 		switch period {
 		case "daily":
+			if wd.Retention.Days == 0 {
+				continue
+			}
 			retentionCount = wd.Retention.Days
 			retentionDate = curDate.AddDate(0, 0, -wd.Retention.Days)
 		case "weekly":
-			if misc.GetDateTimeNow("dow") != misc.WeeklyBackupDay {
+			if misc.GetDateTimeNow("dow") != misc.WeeklyBackupDay || wd.Retention.Weeks == 0 {
 				continue
 			}
 			retentionCount = wd.Retention.Weeks
 			retentionDate = curDate.AddDate(0, 0, -wd.Retention.Weeks*7)
 		case "monthly":
-			if misc.GetDateTimeNow("dom") != misc.MonthlyBackupDay {
+			if misc.GetDateTimeNow("dom") != misc.MonthlyBackupDay || wd.Retention.Months == 0 {
 				continue
 			}
 			retentionCount = wd.Retention.Months


### PR DESCRIPTION
In some cases, rotation was performed incorrectly, which could leave broken symlinks instead of backups. This patch fixes the situation, during rotation symlinks are replaced with backup files.

Additionally, rotation was disabled for periods with a retention value of 0.