### PR TITLE
fix(#44): Fix and refactor backup retention

### DIFF
--- a/ctx/jobs_init.go
+++ b/ctx/jobs_init.go
@@ -74,7 +74,7 @@ func jobsInit(o jobsOpts) ([]interfaces.Job, error) {
 			st.SetBackupPath(opt.BackupPath)
 			st.SetRetention(storage.Retention(opt.Retention))
 
-			if storage.GetNeedToMakeBackup(opt.Retention.Days, opt.Retention.Weeks, opt.Retention.Months) {
+			if storage.IsNeedToBackup(opt.Retention.Days, opt.Retention.Weeks, opt.Retention.Months) {
 				needToMakeBackup = true
 			}
 

--- a/modules/storage/s3/s3.go
+++ b/modules/storage/s3/s3.go
@@ -173,15 +173,15 @@ func (s *s3) DeleteOldBackups(logCh chan logger.LogRecord, ofs string, job inter
 				}
 			}
 		} else {
-			if strings.Contains(object.Key, "daily") && s.Retention.Days > 0 {
+			if strings.Contains(object.Key, Daily.String()) && s.Retention.Days > 0 {
 				if s.Retention.UseCount || object.LastModified.Before(curDate.AddDate(0, 0, -s.Retention.Days)) {
 					filesList["daily"] = append(filesList["daily"], object)
 				}
-			} else if strings.Contains(object.Key, "weekly") && s.Retention.Weeks > 0 && misc.GetDateTimeNow("dow") == misc.WeeklyBackupDay {
+			} else if strings.Contains(object.Key, Weekly.String()) && s.Retention.Weeks > 0 && misc.GetDateTimeNow("dow") == misc.WeeklyBackupDay {
 				if s.Retention.UseCount || object.LastModified.Before(curDate.AddDate(0, 0, -s.Retention.Weeks*7)) {
 					filesList["weekly"] = append(filesList["weekly"], object)
 				}
-			} else if strings.Contains(object.Key, "monthly") && s.Retention.Weeks > 0 && misc.GetDateTimeNow("dom") == misc.MonthlyBackupDay {
+			} else if strings.Contains(object.Key, Monthly.String()) && s.Retention.Weeks > 0 && misc.GetDateTimeNow("dom") == misc.MonthlyBackupDay {
 				if s.Retention.UseCount || object.LastModified.Before(curDate.AddDate(0, -s.Retention.Months, 0)) {
 					filesList["monthly"] = append(filesList["monthly"], object)
 				}

--- a/modules/storage/sftp/sftp.go
+++ b/modules/storage/sftp/sftp.go
@@ -213,34 +213,14 @@ func (s *SFTP) deleteDescBackup(logCh chan logger.LogRecord, jobName, ofsPart st
 	var errs *multierror.Error
 	filesMap := make(map[string]*fileLinks, 64)
 	filesToDeleteMap := make(map[string]*fileLinks, 64)
-	curDate := time.Now().Round(24 * time.Hour)
 
-	for _, period := range []string{"monthly", "weekly", "daily"} {
-		var retentionDate time.Time
-		retentionCount := 0
-
-		switch period {
-		case "daily":
-			if s.Retention.Days == 0 {
-				continue
-			}
-			retentionCount = s.Retention.Days
-			retentionDate = curDate.AddDate(0, 0, -s.Retention.Days)
-		case "weekly":
-			if s.Retention.Weeks == 0 {
-				continue
-			}
-			retentionCount = s.Retention.Weeks
-			retentionDate = curDate.AddDate(0, 0, -s.Retention.Weeks*7)
-		case "monthly":
-			if s.Retention.Months == 0 {
-				continue
-			}
-			retentionCount = s.Retention.Months
-			retentionDate = curDate.AddDate(0, -s.Retention.Months, 0)
+	for _, p := range RetentionPeriodsList {
+		retentionCount, retentionDate := GetRetention(p, s.Retention)
+		if retentionCount == 0 && retentionDate.IsZero() {
+			continue
 		}
 
-		bakDir := path.Join(s.backupPath, ofsPart, period)
+		bakDir := path.Join(s.backupPath, ofsPart, p.String())
 		files, err := s.client.ReadDir(bakDir)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
@@ -263,10 +243,10 @@ func (s *SFTP) deleteDescBackup(logCh chan logger.LogRecord, jobName, ofsPart st
 				linkPath := filepath.Join(bakDir, link)
 
 				if fl, ok := filesMap[linkPath]; ok {
-					switch period {
-					case "weekly":
+					switch p {
+					case Weekly:
 						fl.wLink = fPath
-					case "daily":
+					case Daily:
 						fl.dLink = fPath
 					}
 					filesMap[linkPath] = fl


### PR DESCRIPTION
Fixed issue.
Improved code readability by concentrating similar functionalities into a single function, `GetRetention`, which reduces redundancy and eases maintenance. Also, renamed `GetNeedToMakeBackup` to `IsNeedToBackup` to reflect its boolean nature.

Refs: #44