### PR TITLE
feat(#43): Change var Version instead of constant

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,11 +32,12 @@ jobs:
       with:
         go-version: '1.20'
 
-    - name: Set version
-      run: V=${{ github.ref_name }} && VT="${V#v}" && sed "s@APP_VERSION@$VT@" misc/version.go.in > misc/version.go
+    - name: Get version
+      id: get_version
+      uses: battila7/get-version-action@v2
 
     - name: Build
-      run: GOOS=linux GOARCH=${{ matrix.TARGET }} CGO_ENABLED=0 go build -ldflags="-s -w" -v -o nxs-backup
+      run: GOOS=linux GOARCH=${{ matrix.TARGET }} CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/nixys/nxs-backup/misc.Version=${{ steps.get_version.outputs.version-without-v }}" -v -o nxs-backup
 
     - name: Run UPX
       uses: crazy-max/ghaction-upx@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,8 @@ jobs:
       with:
         go-version: '1.20'
 
-    - name: Set version
-      run: V=${{ github.ref_name }} && VT="${V#v}" && sed "s@APP_VERSION@$VT@" misc/version.go.in > misc/version.go
-
     - name: Build
-      run: CGO_ENABLED=0 go build -v
+      run: CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/nixys/nxs-backup/misc.Version=3-test-build" -v
 
     - name: Test
       run: go test -v ./...

--- a/ctx/args.go
+++ b/ctx/args.go
@@ -71,5 +71,5 @@ func ReadArgs() (p ArgsParams, err error) {
 }
 
 func (args) Version() string {
-	return "nxs-backup " + misc.VERSION
+	return "nxs-backup " + misc.Version
 }

--- a/ctx/context.go
+++ b/ctx/context.go
@@ -165,7 +165,7 @@ func appInit(c *Ctx, cfgPath string) (app, error) {
 
 	if conf.Server.Metrics.Enabled {
 		nva := 0.0
-		ver, _ := semver.NewVersion(misc.VERSION)
+		ver, _ := semver.NewVersion(misc.Version)
 		newVer, _, _ := misc.CheckNewVersionAvailable(strconv.FormatUint(ver.Major(), 10))
 		if newVer != "" {
 			nva = 1

--- a/misc/generals.go
+++ b/misc/generals.go
@@ -37,7 +37,10 @@ const (
 	External             BackupType = "external"
 )
 
-var DecadesBackupDays = []string{"1", "11", "21"}
+var (
+	DecadesBackupDays = []string{"1", "11", "21"}
+	Version           string
+)
 
 func AllowedBackupTypesList() []string {
 	return []string{
@@ -190,7 +193,7 @@ func CheckNewVersionAvailable(ver string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	curVer, err := semver.NewVersion(VERSION)
+	curVer, err := semver.NewVersion(Version)
 	if err != nil {
 		return "", "", err
 	}

--- a/misc/version.go.in
+++ b/misc/version.go.in
@@ -1,4 +1,0 @@
-package misc
-
-// VERSION is a program version generated using nxs-build-tools
-const VERSION = "APP_VERSION"

--- a/modules/storage/sftp/sftp.go
+++ b/modules/storage/sftp/sftp.go
@@ -48,7 +48,7 @@ func Init(name string, params Params) (*SFTP, error) {
 		Auth:            []ssh.AuthMethod{},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		Timeout:         params.ConnectTimeout * time.Second,
-		ClientVersion:   "SSH-2.0-" + "nxs-backup/" + misc.VERSION,
+		ClientVersion:   "SSH-2.0-" + "nxs-backup/" + misc.Version,
 	}
 
 	if params.Password != "" {


### PR DESCRIPTION
Changes:
 - Used `Version` var to set app version instead of constant
 - Updated ci workflow
 - Removed version.go.in file, used for set app version on build step

Refs: #43