### PR TITLE
fix(#47): Fix incremental backup errors

### DIFF
--- a/modules/backup/inc_files/inc_files.go
+++ b/modules/backup/inc_files/inc_files.go
@@ -368,7 +368,7 @@ func (j *job) getMetadataFile(logCh chan logger.LogRecord, ofsPart, metadata str
 		break
 	}
 
-	if reader == nil {
+	if err == nil && reader == nil {
 		err = fs.ErrNotExist
 	}
 

--- a/modules/storage/ftp/ftp.go
+++ b/modules/storage/ftp/ftp.go
@@ -322,7 +322,7 @@ func (f *FTP) GetFileReader(ofsPath string) (io.Reader, error) {
 	}
 
 	// return fs.ErrNotExist if entry not available
-	if _, err := f.conn.GetEntry(ofsPath); err != nil {
+	if _, err := f.conn.GetEntry(path.Join(f.backupPath, ofsPath)); err != nil {
 		protoErr := err.(*textproto.Error)
 		if protoErr.Code == 550 {
 			return nil, fs.ErrNotExist

--- a/modules/storage/smb/smb.go
+++ b/modules/storage/smb/smb.go
@@ -374,7 +374,7 @@ func (s *SMB) deleteIncBackup(logCh chan logger.LogRecord, jobName, ofsPart stri
 }
 
 func (s *SMB) GetFileReader(ofsPath string) (io.Reader, error) {
-	f, err := s.share.Open(ofsPath)
+	f, err := s.share.Open(path.Join(s.backupPath, ofsPath))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/storage/webdav/wedav.go
+++ b/modules/storage/webdav/wedav.go
@@ -317,7 +317,7 @@ func (wd *WebDav) getInfo(dstPath string) (os.FileInfo, error) {
 }
 
 func (wd *WebDav) GetFileReader(ofsPath string) (io.Reader, error) {
-	f, err := wd.client.Read(ofsPath)
+	f, err := wd.client.Read(path.Join(wd.backupPath, ofsPath))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Changes:
- Refactored the path construction in FTP, SMB, SFTP, and WebDav storage modules to incorporate 'backupPath' in GetFileReader function.
- Improved error handling in SFTP's Directory deletion and rotation sections.
- Fixed closing connection on getting file wia SFTP.

Refs: #47