### PR TITLE
fix(#50): Return nil to channel

### DIFF
--- a/modules/cmd_handler/generate_config/generate_config.go
+++ b/modules/cmd_handler/generate_config/generate_config.go
@@ -368,7 +368,7 @@ func (gc *generateConfig) Run() {
 
 	fmt.Printf("Successfully added new sample config file: %s\n", newCfgPath)
 
-	return
+	gc.done <- nil
 }
 
 func genStorageOpts(storages map[string]string, incBackup bool) (sts []storageOptsYaml) {


### PR DESCRIPTION
Returns `nil` to done channel at the end of generate config function.

Refs: #50