### PR TITLE
fix(#51): Update metrics

### DIFF
--- a/ctx/jobs_init.go
+++ b/ctx/jobs_init.go
@@ -27,11 +27,10 @@ import (
 )
 
 type jobsOpts struct {
-	metricsData    *metrics.Data
-	oldMetricsData *metrics.Data
-	mainLim        *limitsConf
-	jobs           []jobConf
-	storages       map[string]interfaces.Storage
+	metricsData *metrics.Data
+	mainLim     *limitsConf
+	jobs        []jobConf
+	storages    map[string]interfaces.Storage
 }
 
 func jobsInit(o jobsOpts) ([]interfaces.Job, error) {
@@ -135,7 +134,6 @@ func jobsInit(o jobsOpts) ([]interfaces.Job, error) {
 				Storages:         jobStorages,
 				Sources:          sources,
 				Metrics:          o.metricsData,
-				OldMetrics:       o.oldMetricsData,
 			})
 
 		case misc.IncFiles:
@@ -160,7 +158,6 @@ func jobsInit(o jobsOpts) ([]interfaces.Job, error) {
 				Storages:        jobStorages,
 				Sources:         sources,
 				Metrics:         o.metricsData,
-				OldMetrics:      o.oldMetricsData,
 			})
 
 		case misc.Mysql:
@@ -200,7 +197,6 @@ func jobsInit(o jobsOpts) ([]interfaces.Job, error) {
 				Storages:         jobStorages,
 				Sources:          sources,
 				Metrics:          o.metricsData,
-				OldMetrics:       o.oldMetricsData,
 			})
 
 		case misc.MysqlXtrabackup:
@@ -241,7 +237,6 @@ func jobsInit(o jobsOpts) ([]interfaces.Job, error) {
 				Storages:         jobStorages,
 				Sources:          sources,
 				Metrics:          o.metricsData,
-				OldMetrics:       o.oldMetricsData,
 			})
 
 		case misc.Postgresql:
@@ -283,7 +278,6 @@ func jobsInit(o jobsOpts) ([]interfaces.Job, error) {
 				Storages:         jobStorages,
 				Sources:          sources,
 				Metrics:          o.metricsData,
-				OldMetrics:       o.oldMetricsData,
 			})
 
 		case misc.PostgresqlBasebackup:
@@ -323,7 +317,6 @@ func jobsInit(o jobsOpts) ([]interfaces.Job, error) {
 				Storages:         jobStorages,
 				Sources:          sources,
 				Metrics:          o.metricsData,
-				OldMetrics:       o.oldMetricsData,
 			})
 
 		case misc.MongoDB:
@@ -366,7 +359,6 @@ func jobsInit(o jobsOpts) ([]interfaces.Job, error) {
 				Storages:         jobStorages,
 				Sources:          sources,
 				Metrics:          o.metricsData,
-				OldMetrics:       o.oldMetricsData,
 			})
 
 		case misc.Redis:
@@ -395,7 +387,6 @@ func jobsInit(o jobsOpts) ([]interfaces.Job, error) {
 				Storages:         jobStorages,
 				Sources:          sources,
 				Metrics:          o.metricsData,
-				OldMetrics:       o.oldMetricsData,
 			})
 
 		case misc.External:
@@ -407,7 +398,6 @@ func jobsInit(o jobsOpts) ([]interfaces.Job, error) {
 				SkipBackupRotate: j.SkipBackupRotate,
 				Storages:         jobStorages,
 				Metrics:          o.metricsData,
-				OldMetrics:       o.oldMetricsData,
 			})
 
 		default:

--- a/interfaces/job.go
+++ b/interfaces/job.go
@@ -7,7 +7,6 @@ import (
 
 type Job interface {
 	SetOfsMetrics(ofs string, metrics map[string]float64)
-	ExportMetrics()
 	GetName() string
 	GetTempDir() string
 	GetType() misc.BackupType

--- a/modules/backup/backup.go
+++ b/modules/backup/backup.go
@@ -49,8 +49,6 @@ func Perform(logCh chan logger.LogRecord, job interfaces.Job) error {
 		errs = multierror.Append(errs, err)
 	}
 
-	job.ExportMetrics()
-
 	_ = job.CleanupTmpData()
 	_ = filepath.Walk(tmpDirPath,
 		func(path string, info os.FileInfo, err error) error {

--- a/modules/backup/desc_files/desc_files.go
+++ b/modules/backup/desc_files/desc_files.go
@@ -31,7 +31,6 @@ type job struct {
 	targets          map[string]target
 	dumpedObjects    map[string]interfaces.DumpObject
 	appMetrics       *metrics.Data
-	jobMetrics       metrics.JobData
 }
 
 type target struct {
@@ -51,7 +50,6 @@ type JobParams struct {
 	Storages         interfaces.Storages
 	Sources          []SourceParams
 	Metrics          *metrics.Data
-	OldMetrics       *metrics.Data
 }
 
 type SourceParams struct {
@@ -79,15 +77,14 @@ func Init(jp JobParams) (interfaces.Job, error) {
 		storages:         jp.Storages,
 		targets:          make(map[string]target),
 		dumpedObjects:    make(map[string]interfaces.DumpObject),
-		appMetrics:       jp.Metrics,
-		jobMetrics: metrics.JobData{
-			JobName:       jp.Name,
-			JobType:       misc.DescFiles,
-			TargetMetrics: make(map[string]metrics.TargetData),
-		},
+		appMetrics: jp.Metrics.RegisterJob(
+			metrics.JobData{
+				JobName:       jp.Name,
+				JobType:       misc.DescFiles,
+				TargetMetrics: make(map[string]metrics.TargetData),
+			},
+		),
 	}
-
-	ojm := jp.OldMetrics.GetMetrics(jp.Name)
 
 	for _, src := range jp.Sources {
 
@@ -128,32 +125,23 @@ func Init(jp JobParams) (interfaces.Job, error) {
 						saveAbsPath: src.SaveAbsPath,
 						excludes:    excludes,
 					}
-					if otm, ok := ojm.TargetMetrics[ofs]; ok {
-						j.jobMetrics.TargetMetrics[ofs] = otm
-					} else {
-						j.jobMetrics.TargetMetrics[ofs] = metrics.TargetData{
-							Source: src.Name,
-							Target: ofsPart,
-							Values: make(map[string]float64),
-						}
+					j.appMetrics.Job[jp.Name].TargetMetrics[ofs] = metrics.TargetData{
+						Source: src.Name,
+						Target: ofsPart,
+						Values: make(map[string]float64),
 					}
 				}
 			}
 		}
 	}
 
-	j.ExportMetrics()
 	return &j, nil
 }
 
 func (j *job) SetOfsMetrics(ofs string, metricsMap map[string]float64) {
 	for m, v := range metricsMap {
-		j.jobMetrics.TargetMetrics[ofs].Values[m] = v
+		j.appMetrics.Job[j.name].TargetMetrics[ofs].Values[m] = v
 	}
-}
-
-func (j *job) ExportMetrics() {
-	j.appMetrics.JobMetricsSet(j.jobMetrics)
 }
 
 func (j *job) GetName() string {
@@ -214,12 +202,15 @@ func (j *job) DoBackup(logCh chan logger.LogRecord, tmpDir string) error {
 	var errs *multierror.Error
 
 	for ofsPart, tgt := range j.targets {
+		startTime := time.Now()
+
 		j.SetOfsMetrics(ofsPart, map[string]float64{
-			metrics.BackupOk:     float64(0),
-			metrics.BackupTime:   float64(0),
-			metrics.DeliveryOk:   float64(0),
-			metrics.DeliveryTime: float64(0),
-			metrics.BackupSize:   float64(0),
+			metrics.BackupOk:        float64(0),
+			metrics.BackupTime:      float64(0),
+			metrics.DeliveryOk:      float64(0),
+			metrics.DeliveryTime:    float64(0),
+			metrics.BackupSize:      float64(0),
+			metrics.BackupTimestamp: float64(startTime.Unix()),
 		})
 
 		tmpBackupFile := misc.GetFileFullPath(tmpDir, ofsPart, "tar", "", tgt.gzip)
@@ -230,7 +221,6 @@ func (j *job) DoBackup(logCh chan logger.LogRecord, tmpDir string) error {
 			continue
 		}
 
-		startTime := time.Now()
 		if err = targz.Tar(targz.TarOpts{
 			Src:         tgt.path,
 			Dst:         tmpBackupFile,

--- a/modules/backup/inc_files/inc_files.go
+++ b/modules/backup/inc_files/inc_files.go
@@ -32,7 +32,6 @@ type job struct {
 	targets         map[string]target
 	dumpedObjects   map[string]interfaces.DumpObject
 	appMetrics      *metrics.Data
-	jobMetrics      metrics.JobData
 }
 
 type target struct {
@@ -51,7 +50,6 @@ type JobParams struct {
 	Storages        interfaces.Storages
 	Sources         []SourceParams
 	Metrics         *metrics.Data
-	OldMetrics      *metrics.Data
 }
 
 type SourceParams struct {
@@ -77,15 +75,14 @@ func Init(jp JobParams) (interfaces.Job, error) {
 		storages:        jp.Storages,
 		dumpedObjects:   make(map[string]interfaces.DumpObject),
 		targets:         make(map[string]target),
-		appMetrics:      jp.Metrics,
-		jobMetrics: metrics.JobData{
-			JobName:       jp.Name,
-			JobType:       misc.IncFiles,
-			TargetMetrics: make(map[string]metrics.TargetData),
-		},
+		appMetrics: jp.Metrics.RegisterJob(
+			metrics.JobData{
+				JobName:       jp.Name,
+				JobType:       misc.IncFiles,
+				TargetMetrics: make(map[string]metrics.TargetData),
+			},
+		),
 	}
-
-	ojm := jp.OldMetrics.GetMetrics(jp.Name)
 
 	for _, src := range jp.Sources {
 
@@ -126,32 +123,23 @@ func Init(jp JobParams) (interfaces.Job, error) {
 						saveAbsPath: src.SaveAbsPath,
 						excludes:    excludes,
 					}
-					if otm, ok := ojm.TargetMetrics[ofs]; ok {
-						j.jobMetrics.TargetMetrics[ofs] = otm
-					} else {
-						j.jobMetrics.TargetMetrics[ofs] = metrics.TargetData{
-							Source: src.Name,
-							Target: ofsPart,
-							Values: make(map[string]float64),
-						}
+					j.appMetrics.Job[jp.Name].TargetMetrics[ofs] = metrics.TargetData{
+						Source: src.Name,
+						Target: ofsPart,
+						Values: make(map[string]float64),
 					}
 				}
 			}
 		}
 	}
 
-	j.ExportMetrics()
 	return &j, nil
 }
 
 func (j *job) SetOfsMetrics(ofs string, metricsMap map[string]float64) {
 	for m, v := range metricsMap {
-		j.jobMetrics.TargetMetrics[ofs].Values[m] = v
+		j.appMetrics.Job[j.name].TargetMetrics[ofs].Values[m] = v
 	}
-}
-
-func (j *job) ExportMetrics() {
-	j.appMetrics.JobMetricsSet(j.jobMetrics)
 }
 
 func (j *job) GetName() string {
@@ -212,12 +200,15 @@ func (j *job) DoBackup(logCh chan logger.LogRecord, tmpDir string) error {
 	var errs *multierror.Error
 
 	for ofsPart, tgt := range j.targets {
+		startTime := time.Now()
+
 		j.SetOfsMetrics(ofsPart, map[string]float64{
-			metrics.BackupOk:     float64(0),
-			metrics.BackupTime:   float64(0),
-			metrics.DeliveryOk:   float64(0),
-			metrics.DeliveryTime: float64(0),
-			metrics.BackupSize:   float64(0),
+			metrics.BackupOk:        float64(0),
+			metrics.BackupTime:      float64(0),
+			metrics.DeliveryOk:      float64(0),
+			metrics.DeliveryTime:    float64(0),
+			metrics.BackupSize:      float64(0),
+			metrics.BackupTimestamp: float64(startTime.Unix()),
 		})
 
 		tmpBackupFile := misc.GetFileFullPath(tmpDir, ofsPart, "tar", "", tgt.gzip)
@@ -245,7 +236,6 @@ func (j *job) DoBackup(logCh chan logger.LogRecord, tmpDir string) error {
 			}
 		}
 
-		startTime := time.Now()
 		if err = targz.Tar(targz.TarOpts{
 			Src:         tgt.path,
 			Dst:         tmpBackupFile,

--- a/modules/backup/mysql_xtrabackup/mysql_xtrabackup.go
+++ b/modules/backup/mysql_xtrabackup/mysql_xtrabackup.go
@@ -35,7 +35,6 @@ type job struct {
 	targets          map[string]target
 	dumpedObjects    map[string]interfaces.DumpObject
 	appMetrics       *metrics.Data
-	jobMetrics       metrics.JobData
 }
 
 type target struct {
@@ -57,7 +56,6 @@ type JobParams struct {
 	Storages         interfaces.Storages
 	Sources          []SourceParams
 	Metrics          *metrics.Data
-	OldMetrics       *metrics.Data
 }
 
 type SourceParams struct {
@@ -92,15 +90,14 @@ func Init(jp JobParams) (interfaces.Job, error) {
 		storages:         jp.Storages,
 		targets:          make(map[string]target),
 		dumpedObjects:    make(map[string]interfaces.DumpObject),
-		appMetrics:       jp.Metrics,
-		jobMetrics: metrics.JobData{
-			JobName:       jp.Name,
-			JobType:       misc.MysqlXtrabackup,
-			TargetMetrics: make(map[string]metrics.TargetData),
-		},
+		appMetrics: jp.Metrics.RegisterJob(
+			metrics.JobData{
+				JobName:       jp.Name,
+				JobType:       misc.MysqlXtrabackup,
+				TargetMetrics: make(map[string]metrics.TargetData),
+			},
+		),
 	}
-
-	ojm := jp.OldMetrics.GetMetrics(jp.Name)
 
 	for _, src := range jp.Sources {
 
@@ -126,29 +123,20 @@ func Init(jp JobParams) (interfaces.Job, error) {
 			isSlave:         src.IsSlave,
 			prepare:         src.Prepare,
 		}
-		if otm, ok := ojm.TargetMetrics[src.Name]; ok {
-			j.jobMetrics.TargetMetrics[src.Name] = otm
-		} else {
-			j.jobMetrics.TargetMetrics[src.Name] = metrics.TargetData{
-				Source: src.Name,
-				Target: "",
-				Values: make(map[string]float64),
-			}
+		j.appMetrics.Job[j.name].TargetMetrics[src.Name] = metrics.TargetData{
+			Source: src.Name,
+			Target: "",
+			Values: make(map[string]float64),
 		}
 	}
 
-	j.ExportMetrics()
 	return &j, nil
 }
 
 func (j *job) SetOfsMetrics(ofs string, metricsMap map[string]float64) {
 	for m, v := range metricsMap {
-		j.jobMetrics.TargetMetrics[ofs].Values[m] = v
+		j.appMetrics.Job[j.name].TargetMetrics[ofs].Values[m] = v
 	}
-}
-
-func (j *job) ExportMetrics() {
-	j.appMetrics.JobMetricsSet(j.jobMetrics)
 }
 
 func (j *job) GetName() string {
@@ -209,12 +197,15 @@ func (j *job) DoBackup(logCh chan logger.LogRecord, tmpDir string) error {
 	var errs *multierror.Error
 
 	for ofsPart, tgt := range j.targets {
+		startTime := time.Now()
+
 		j.SetOfsMetrics(ofsPart, map[string]float64{
-			metrics.BackupOk:     float64(0),
-			metrics.BackupTime:   float64(0),
-			metrics.DeliveryOk:   float64(0),
-			metrics.DeliveryTime: float64(0),
-			metrics.BackupSize:   float64(0),
+			metrics.BackupOk:        float64(0),
+			metrics.BackupTime:      float64(0),
+			metrics.DeliveryOk:      float64(0),
+			metrics.DeliveryTime:    float64(0),
+			metrics.BackupSize:      float64(0),
+			metrics.BackupTimestamp: float64(startTime.Unix()),
 		})
 
 		tmpBackupFile := misc.GetFileFullPath(tmpDir, ofsPart, "tar", "", tgt.gzip)
@@ -225,7 +216,6 @@ func (j *job) DoBackup(logCh chan logger.LogRecord, tmpDir string) error {
 			continue
 		}
 
-		startTime := time.Now()
 		if err = j.createTmpBackup(logCh, tmpBackupFile, ofsPart, tgt); err != nil {
 			j.SetOfsMetrics(ofsPart, map[string]float64{
 				metrics.BackupTime: float64(time.Since(startTime).Nanoseconds() / 1e6),

--- a/modules/backup/psql/psql.go
+++ b/modules/backup/psql/psql.go
@@ -34,7 +34,6 @@ type job struct {
 	targets          map[string]target
 	dumpedObjects    map[string]interfaces.DumpObject
 	appMetrics       *metrics.Data
-	jobMetrics       metrics.JobData
 }
 
 type target struct {
@@ -55,7 +54,6 @@ type JobParams struct {
 	Storages         interfaces.Storages
 	Sources          []SourceParams
 	Metrics          *metrics.Data
-	OldMetrics       *metrics.Data
 }
 
 type SourceParams struct {
@@ -86,15 +84,14 @@ func Init(jp JobParams) (interfaces.Job, error) {
 		storages:         jp.Storages,
 		targets:          make(map[string]target),
 		dumpedObjects:    make(map[string]interfaces.DumpObject),
-		appMetrics:       jp.Metrics,
-		jobMetrics: metrics.JobData{
-			JobName:       jp.Name,
-			JobType:       misc.Postgresql,
-			TargetMetrics: make(map[string]metrics.TargetData),
-		},
+		appMetrics: jp.Metrics.RegisterJob(
+			metrics.JobData{
+				JobName:       jp.Name,
+				JobType:       misc.Postgresql,
+				TargetMetrics: make(map[string]metrics.TargetData),
+			},
+		),
 	}
-
-	ojm := jp.OldMetrics.GetMetrics(jp.Name)
 
 	for _, src := range jp.Sources {
 
@@ -164,30 +161,21 @@ func Init(jp JobParams) (interfaces.Job, error) {
 				extraKeys:    src.ExtraKeys,
 				gzip:         src.Gzip,
 			}
-			if otm, ok := ojm.TargetMetrics[ofs]; ok {
-				j.jobMetrics.TargetMetrics[ofs] = otm
-			} else {
-				j.jobMetrics.TargetMetrics[ofs] = metrics.TargetData{
-					Source: src.Name,
-					Target: db,
-					Values: make(map[string]float64),
-				}
+			j.appMetrics.Job[j.name].TargetMetrics[ofs] = metrics.TargetData{
+				Source: src.Name,
+				Target: db,
+				Values: make(map[string]float64),
 			}
 		}
 	}
 
-	j.ExportMetrics()
 	return &j, nil
 }
 
 func (j *job) SetOfsMetrics(ofs string, metricsMap map[string]float64) {
 	for m, v := range metricsMap {
-		j.jobMetrics.TargetMetrics[ofs].Values[m] = v
+		j.appMetrics.Job[j.name].TargetMetrics[ofs].Values[m] = v
 	}
-}
-
-func (j *job) ExportMetrics() {
-	j.appMetrics.JobMetricsSet(j.jobMetrics)
 }
 
 func (j *job) GetName() string {
@@ -248,12 +236,15 @@ func (j *job) DoBackup(logCh chan logger.LogRecord, tmpDir string) error {
 	var errs *multierror.Error
 
 	for ofsPart, tgt := range j.targets {
+		startTime := time.Now()
+
 		j.SetOfsMetrics(ofsPart, map[string]float64{
-			metrics.BackupOk:     float64(0),
-			metrics.BackupTime:   float64(0),
-			metrics.DeliveryOk:   float64(0),
-			metrics.DeliveryTime: float64(0),
-			metrics.BackupSize:   float64(0),
+			metrics.BackupOk:        float64(0),
+			metrics.BackupTime:      float64(0),
+			metrics.DeliveryOk:      float64(0),
+			metrics.DeliveryTime:    float64(0),
+			metrics.BackupSize:      float64(0),
+			metrics.BackupTimestamp: float64(startTime.Unix()),
 		})
 
 		tmpBackupFile := misc.GetFileFullPath(tmpDir, ofsPart, "sql", "", tgt.gzip)
@@ -264,7 +255,6 @@ func (j *job) DoBackup(logCh chan logger.LogRecord, tmpDir string) error {
 			continue
 		}
 
-		startTime := time.Now()
 		if err = j.createTmpBackup(logCh, tmpBackupFile, tgt); err != nil {
 			j.SetOfsMetrics(ofsPart, map[string]float64{
 				metrics.BackupTime: float64(time.Since(startTime).Nanoseconds() / 1e6),

--- a/modules/backup/psql_basebackup/psql_basebackup.go
+++ b/modules/backup/psql_basebackup/psql_basebackup.go
@@ -33,7 +33,6 @@ type job struct {
 	targets          map[string]target
 	dumpedObjects    map[string]interfaces.DumpObject
 	appMetrics       *metrics.Data
-	jobMetrics       metrics.JobData
 }
 
 type target struct {
@@ -52,7 +51,6 @@ type JobParams struct {
 	Storages         interfaces.Storages
 	Sources          []SourceParams
 	Metrics          *metrics.Data
-	OldMetrics       *metrics.Data
 }
 
 type SourceParams struct {
@@ -84,15 +82,14 @@ func Init(jp JobParams) (interfaces.Job, error) {
 		storages:         jp.Storages,
 		targets:          make(map[string]target),
 		dumpedObjects:    make(map[string]interfaces.DumpObject),
-		appMetrics:       jp.Metrics,
+		appMetrics: jp.Metrics.RegisterJob(
+			metrics.JobData{
+				JobName:       jp.Name,
+				JobType:       misc.PostgresqlBasebackup,
+				TargetMetrics: make(map[string]metrics.TargetData),
+			},
+		),
 	}
-
-	j.jobMetrics = metrics.JobData{
-		JobName:       jp.Name,
-		JobType:       j.GetType(),
-		TargetMetrics: make(map[string]metrics.TargetData),
-	}
-	ojm := jp.OldMetrics.GetMetrics(jp.Name)
 
 	for _, src := range jp.Sources {
 
@@ -124,29 +121,20 @@ func Init(jp JobParams) (interfaces.Job, error) {
 			gzip:      src.Gzip,
 			connUrl:   connUrl,
 		}
-		if otm, ok := ojm.TargetMetrics[src.Name]; ok {
-			j.jobMetrics.TargetMetrics[src.Name] = otm
-		} else {
-			j.jobMetrics.TargetMetrics[src.Name] = metrics.TargetData{
-				Source: src.Name,
-				Target: "",
-				Values: make(map[string]float64),
-			}
+		j.appMetrics.Job[j.name].TargetMetrics[src.Name] = metrics.TargetData{
+			Source: src.Name,
+			Target: "",
+			Values: make(map[string]float64),
 		}
 	}
 
-	j.ExportMetrics()
 	return &j, nil
 }
 
 func (j *job) SetOfsMetrics(ofs string, metricsMap map[string]float64) {
 	for m, v := range metricsMap {
-		j.jobMetrics.TargetMetrics[ofs].Values[m] = v
+		j.appMetrics.Job[j.name].TargetMetrics[ofs].Values[m] = v
 	}
-}
-
-func (j *job) ExportMetrics() {
-	j.appMetrics.JobMetricsSet(j.jobMetrics)
 }
 
 func (j *job) GetName() string {
@@ -207,12 +195,15 @@ func (j *job) DoBackup(logCh chan logger.LogRecord, tmpDir string) error {
 	var errs *multierror.Error
 
 	for ofsPart, tgt := range j.targets {
+		startTime := time.Now()
+
 		j.SetOfsMetrics(ofsPart, map[string]float64{
-			metrics.BackupOk:     float64(0),
-			metrics.BackupTime:   float64(0),
-			metrics.DeliveryOk:   float64(0),
-			metrics.DeliveryTime: float64(0),
-			metrics.BackupSize:   float64(0),
+			metrics.BackupOk:        float64(0),
+			metrics.BackupTime:      float64(0),
+			metrics.DeliveryOk:      float64(0),
+			metrics.DeliveryTime:    float64(0),
+			metrics.BackupSize:      float64(0),
+			metrics.BackupTimestamp: float64(startTime.Unix()),
 		})
 
 		tmpBackupFile := misc.GetFileFullPath(tmpDir, ofsPart, "tar", "", tgt.gzip)
@@ -223,7 +214,6 @@ func (j *job) DoBackup(logCh chan logger.LogRecord, tmpDir string) error {
 			continue
 		}
 
-		startTime := time.Now()
 		if err = j.createTmpBackup(logCh, tmpBackupFile, ofsPart, tgt); err != nil {
 			j.SetOfsMetrics(ofsPart, map[string]float64{
 				metrics.BackupTime: float64(time.Since(startTime).Nanoseconds() / 1e6),

--- a/modules/metrics/exporter.go
+++ b/modules/metrics/exporter.go
@@ -37,6 +37,11 @@ func InitExporter(s ExporterOpts) *Exporter {
 			"Backup collection time",
 			[]string{"project", "server", "job_name", "job_type", "source", "target"}, nil,
 		),
+		BackupTimestamp: prometheus.NewDesc(
+			prometheus.BuildFQName("nxs_backup", "creation", "ts"),
+			"Backup creation timestamp",
+			[]string{"project", "server", "job_name", "job_type", "source", "target"}, nil,
+		),
 		DeliveryOk: prometheus.NewDesc(
 			prometheus.BuildFQName("nxs_backup", "delivery", "success"),
 			"Backup delivery finished successfully",


### PR DESCRIPTION
The changes include:
- The metrics data is now initialized by passing the instance through the application, not by reading from a file.
- Removal of old metrics data and omitting the export of metrics in each job type.
- Each job type now registers its metrics within the initializer.
- A new metric `BackupTimestamp` has been added to represent each backup creation date.

Refs: #51