### PR TITLE
feat(#45): Add 'rotateEnabled' option for backup rotation settings

### DIFF
--- a/ctx/conf.go
+++ b/ctx/conf.go
@@ -82,7 +82,7 @@ type jobConf struct {
 	Sources          []sourceConf    `conf:"sources"`
 	StoragesOptions  []storageConf   `conf:"storages_options"`
 	DumpCmd          string          `conf:"dump_cmd"`
-	SkipBackupRotate bool            `conf:"skip_backup_rotate" conf_extraopts:"default=false"` // used by external
+	SkipBackupRotate bool            `conf:"skip_backup_rotate" conf_extraopts:"default=false"` // deprecated, used by external
 	Limits           *limitsConf     `conf:"limits"`
 }
 
@@ -119,9 +119,10 @@ type sourceConnectConf struct {
 }
 
 type storageConf struct {
-	StorageName string        `conf:"storage_name" conf_extraopts:"required"`
-	BackupPath  string        `conf:"backup_path" conf_extraopts:"required"`
-	Retention   retentionConf `conf:"retention" conf_extraopts:"required"`
+	StorageName  string        `conf:"storage_name" conf_extraopts:"required"`
+	BackupPath   string        `conf:"backup_path" conf_extraopts:"required"`
+	EnableRotate bool          `conf:"enable_rotate" conf_extraopts:"default=true"`
+	Retention    retentionConf `conf:"retention" conf_extraopts:"required"`
 }
 
 type retentionConf struct {

--- a/ctx/context.go
+++ b/ctx/context.go
@@ -285,3 +285,7 @@ func getRateLimit(limit *string) (rl int64, err error) {
 
 	return
 }
+
+func checkDeprecated(o ConfOpts) {
+
+}

--- a/interfaces/storage.go
+++ b/interfaces/storage.go
@@ -16,12 +16,10 @@ import (
 
 type Storage interface {
 	IsLocal() int
-	SetBackupPath(path string)
-	SetRateLimit(rl int64)
-	SetRetention(r storage.Retention)
+	Configure(storage.Params)
 	DeliveryBackup(logCh chan logger.LogRecord, jobName, tmpBackupPath, ofs, bakType string) error
 	DeleteOldBackups(logCh chan logger.LogRecord, ofsPart string, job Job, full bool) error
-	GetFileReader(path string) (io.Reader, error)
+	GetFileReader(string) (io.Reader, error)
 	Close() error
 	Clone() Storage
 	GetName() string

--- a/modules/backup/external/external.go
+++ b/modules/backup/external/external.go
@@ -21,7 +21,7 @@ type job struct {
 	envs             map[string]string
 	needToMakeBackup bool
 	safetyBackup     bool
-	skipBackupRotate bool
+	skipBackupRotate bool // deprecated
 	storages         interfaces.Storages
 	dumpedObjects    map[string]interfaces.DumpObject
 	appMetrics       *metrics.Data
@@ -34,7 +34,7 @@ type JobParams struct {
 	Envs             map[string]string
 	NeedToMakeBackup bool
 	SafetyBackup     bool
-	SkipBackupRotate bool
+	SkipBackupRotate bool // deprecated
 	Storages         interfaces.Storages
 	Metrics          *metrics.Data
 }

--- a/modules/cmd_handler/generate_config/generate_config.go
+++ b/modules/cmd_handler/generate_config/generate_config.go
@@ -56,9 +56,10 @@ type srcConnectYaml struct {
 }
 
 type storageOptsYaml struct {
-	StorageName string           `yaml:"storage_name"`
-	BackupPath  string           `yaml:"backup_path"`
-	Retention   cfgRetentionYaml `yaml:"retention"`
+	StorageName  string           `yaml:"storage_name"`
+	BackupPath   string           `yaml:"backup_path"`
+	EnableRotate bool             `yaml:"enable_rotate"`
+	Retention    cfgRetentionYaml `yaml:"retention"`
 }
 
 type cfgRetentionYaml struct {
@@ -384,16 +385,18 @@ func genStorageOpts(storages map[string]string, incBackup bool) (sts []storageOp
 	}
 
 	sts = append(sts, storageOptsYaml{
-		StorageName: "local",
-		BackupPath:  "/var/nxs-backup/dump",
-		Retention:   defaultRetention,
+		StorageName:  "local",
+		BackupPath:   "/var/nxs-backup/dump",
+		EnableRotate: true,
+		Retention:    defaultRetention,
 	})
 
 	for nm := range storages {
 		sts = append(sts, storageOptsYaml{
-			StorageName: nm,
-			BackupPath:  "/nxs-backup/dump",
-			Retention:   defaultRetention,
+			StorageName:  nm,
+			BackupPath:   "/nxs-backup/dump",
+			EnableRotate: true,
+			Retention:    defaultRetention,
 		})
 	}
 

--- a/modules/storage/common.go
+++ b/modules/storage/common.go
@@ -22,6 +22,13 @@ const (
 
 var RetentionPeriodsList = []retentionPeriod{Monthly, Weekly, Daily}
 
+type Params struct {
+	RateLimit     int64
+	BackupPath    string
+	RotateEnabled bool
+	Retention
+}
+
 type Retention struct {
 	Days     int
 	Weeks    int


### PR DESCRIPTION
Changes:
- Replaced individual setter methods for storage with a new Configure method that uses a Params struct.
- Added a new 'rotateEnabled' field in the Params struct for storage and implemented backup rotation control.
- Updated use of 'SkipBackupRotate' option which is now deprecated, and replaced with 'storages_options[].enable_rotate'.
- Added error message if used deprecated 'skip_backup_rotate' option.
- Reflect the changes in configuration of all storage types.
- Updated the generate_config module to use the new 'enable_rotate' setting.

Refs: #45