### PR TITLE
feat: Add backup list functionality

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -13,6 +13,10 @@ changelog:
     labels:
     - Semver-Minor
     - enhancement
+  - title: Fixes 🪲
+    labels:
+      - Semver-Patch
+      - bug
   - title: Other Changes
     labels:
     - "*"

--- a/ctx/args.go
+++ b/ctx/args.go
@@ -3,22 +3,35 @@ package ctx
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/alexflint/go-arg"
 
 	"github.com/nixys/nxs-backup/misc"
 )
 
+type command string
+
+const (
+	start     command = "start"
+	server    command = "server"
+	generate  command = "generate"
+	update    command = "update"
+	lsBackups command = "ls_backups"
+	testCfg   command = "test_cfg"
+	unknown   command = "unknown"
+)
+
 // ArgsParams contains parameters read from command line, command parameters and command handler
 type ArgsParams struct {
 	ConfigPath string
-	Cmd        string
+	Cmd        command
 	CmdParams  interface{}
 	Arg        *arg.Parser
 }
 
 type StartCmd struct {
-	JobName string `arg:"positional" placeholder:"JOB GROUP/NAME" default:"all"`
+	JobName string `arg:"positional" help:"Name of job or jobs group to run [default: all]" default:"all" placeholder:"JOB_NAME/GROUP_NAME"`
 }
 
 // ServerCmd "Running the nxs-backup in server mode"
@@ -30,6 +43,10 @@ type GenerateCmd struct {
 	OutPath  string            `arg:"-O,--out-path" help:"Path to the generated configuration file" placeholder:"PATH"`
 }
 
+type ListCmd struct {
+	Backups *StartCmd `arg:"subcommand:backups"`
+}
+
 type UpdateCmd struct {
 	Version string `arg:"-V,--set-version" help:"Use the specific version to update. Example: -V 3.2.0-rc0" default:"3"`
 }
@@ -39,6 +56,7 @@ type args struct {
 	Server   *ServerCmd   `arg:"subcommand:server"`
 	Generate *GenerateCmd `arg:"subcommand:generate"`
 	Update   *UpdateCmd   `arg:"subcommand:update"`
+	List     *ListCmd     `arg:"subcommand:ls"`
 	ConfPath string       `arg:"-c,--config" help:"Path to config file" default:"/etc/nxs-backup/nxs-backup.conf" placeholder:"PATH"`
 	TestConf bool         `arg:"-t,--test-config" help:"Check if configuration correct"`
 }
@@ -53,7 +71,7 @@ func ReadArgs() (p ArgsParams, err error) {
 	p.ConfigPath = a.ConfPath
 
 	if a.TestConf {
-		p.Cmd = "testCfg"
+		p.Cmd = testCfg
 		return
 	}
 
@@ -63,7 +81,14 @@ func ReadArgs() (p ArgsParams, err error) {
 		curArgs.WriteHelp(os.Stderr)
 		return p, misc.ErrArg
 	}
-	p.Cmd = subCmds[0]
+
+	cmd := getCmd(strings.Join(subCmds, "_"))
+	if cmd == unknown {
+		_, _ = fmt.Fprintln(os.Stderr, "Unknown command")
+		curArgs.WriteHelp(os.Stderr)
+		return p, misc.ErrArg
+	}
+	p.Cmd = cmd
 	p.CmdParams = curArgs.Subcommand()
 	p.Arg = curArgs
 
@@ -72,4 +97,23 @@ func ReadArgs() (p ArgsParams, err error) {
 
 func (args) Version() string {
 	return "nxs-backup " + misc.VERSION
+}
+
+func getCmd(argCmd string) command {
+	switch command(argCmd) {
+	case start:
+		return start
+	case server:
+		return server
+	case generate:
+		return generate
+	case update:
+		return update
+	case lsBackups:
+		return lsBackups
+	case testCfg:
+		return testCfg
+	default:
+		return unknown
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/alexflint/go-arg v1.5.0
 	github.com/docker/go-units v0.5.0
+	github.com/fatih/color v1.17.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/go-sql-driver/mysql v1.8.1
@@ -62,6 +63,7 @@ require (
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
+github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/gabriel-vasile/mimetype v1.4.4 h1:QjV6pZ7/XZ7ryI2KuyeEDE8wnh7fHP9YnQy+R0LnH8I=
 github.com/gabriel-vasile/mimetype v1.4.4/go.mod h1:JwLei5XPtWdGiMFB5Pjle1oEeoSeEuJfJE+TtfvdB/s=
@@ -96,6 +98,9 @@ github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
@@ -209,6 +214,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/interfaces/job.go
+++ b/interfaces/job.go
@@ -5,6 +5,8 @@ import (
 	"github.com/nixys/nxs-backup/modules/logger"
 )
 
+type JobTargets map[string]TargetsOnStorages
+
 type Job interface {
 	SetOfsMetrics(ofs string, metrics map[string]float64)
 	GetName() string
@@ -15,6 +17,7 @@ type Job interface {
 	GetDumpObjects() map[string]DumpObject
 	SetDumpObjectDelivered(ofs string)
 	IsBackupSafety() bool
+	ListBackups() JobTargets
 	NeedToMakeBackup() bool
 	NeedToUpdateIncMeta() bool
 	DoBackup(logCh chan logger.LogRecord, tmpDir string) error

--- a/misc/errors.go
+++ b/misc/errors.go
@@ -6,4 +6,5 @@ var (
 	ErrArg            = errors.New("incorrect arguments")
 	ErrArgSuccessExit = errors.New("arg success exit")
 	ErrConfig         = errors.New("config incorrect")
+	ErrExecution      = errors.New("execution finished with errors")
 )

--- a/modules/backup/desc_files/desc_files.go
+++ b/modules/backup/desc_files/desc_files.go
@@ -171,6 +171,17 @@ func (j *job) GetDumpObjects() map[string]interfaces.DumpObject {
 	return j.dumpedObjects
 }
 
+func (j *job) ListBackups() interfaces.JobTargets {
+	jt := make(interfaces.JobTargets)
+
+	for tn := range j.targets {
+		jt[tn] = make(interfaces.TargetsOnStorages)
+		jt[tn] = j.storages.ListBackups(tn)
+	}
+
+	return jt
+}
+
 func (j *job) SetDumpObjectDelivered(ofs string) {
 	dumpObj := j.dumpedObjects[ofs]
 	dumpObj.Delivered = true

--- a/modules/backup/external/external.go
+++ b/modules/backup/external/external.go
@@ -106,6 +106,16 @@ func (j *job) GetDumpObjects() map[string]interfaces.DumpObject {
 	return j.dumpedObjects
 }
 
+func (j *job) ListBackups() interfaces.JobTargets {
+	jt := make(interfaces.JobTargets)
+	tn := j.dumpCmd
+
+	jt[tn] = make(interfaces.TargetsOnStorages)
+	jt[tn] = j.storages.ListBackups("")
+
+	return jt
+}
+
 func (j *job) SetDumpObjectDelivered(ofs string) {
 	dumpObj := j.dumpedObjects[ofs]
 	dumpObj.Delivered = true

--- a/modules/backup/inc_files/inc_files.go
+++ b/modules/backup/inc_files/inc_files.go
@@ -169,6 +169,17 @@ func (j *job) GetDumpObjects() map[string]interfaces.DumpObject {
 	return j.dumpedObjects
 }
 
+func (j *job) ListBackups() interfaces.JobTargets {
+	jt := make(interfaces.JobTargets)
+
+	for tn := range j.targets {
+		jt[tn] = make(interfaces.TargetsOnStorages)
+		jt[tn] = j.storages.ListBackups(tn)
+	}
+
+	return jt
+}
+
 func (j *job) SetDumpObjectDelivered(ofs string) {
 	dumpObj := j.dumpedObjects[ofs]
 	dumpObj.Delivered = true

--- a/modules/backup/mongodump/mongodump.go
+++ b/modules/backup/mongodump/mongodump.go
@@ -204,6 +204,17 @@ func (j *job) GetDumpObjects() map[string]interfaces.DumpObject {
 	return j.dumpedObjects
 }
 
+func (j *job) ListBackups() interfaces.JobTargets {
+	jt := make(interfaces.JobTargets)
+
+	for tn := range j.targets {
+		jt[tn] = make(interfaces.TargetsOnStorages)
+		jt[tn] = j.storages.ListBackups(tn)
+	}
+
+	return jt
+}
+
 func (j *job) SetDumpObjectDelivered(ofs string) {
 	dumpObj := j.dumpedObjects[ofs]
 	dumpObj.Delivered = true

--- a/modules/backup/mysql/mysql.go
+++ b/modules/backup/mysql/mysql.go
@@ -179,6 +179,17 @@ func (j *job) GetDumpObjects() map[string]interfaces.DumpObject {
 	return j.dumpedObjects
 }
 
+func (j *job) ListBackups() interfaces.JobTargets {
+	jt := make(interfaces.JobTargets)
+
+	for tn := range j.targets {
+		jt[tn] = make(interfaces.TargetsOnStorages)
+		jt[tn] = j.storages.ListBackups(tn)
+	}
+
+	return jt
+}
+
 func (j *job) SetDumpObjectDelivered(ofs string) {
 	dumpObj := j.dumpedObjects[ofs]
 	dumpObj.Delivered = true

--- a/modules/backup/mysql_xtrabackup/mysql_xtrabackup.go
+++ b/modules/backup/mysql_xtrabackup/mysql_xtrabackup.go
@@ -166,6 +166,17 @@ func (j *job) GetDumpObjects() map[string]interfaces.DumpObject {
 	return j.dumpedObjects
 }
 
+func (j *job) ListBackups() interfaces.JobTargets {
+	jt := make(interfaces.JobTargets)
+
+	for tn := range j.targets {
+		jt[tn] = make(interfaces.TargetsOnStorages)
+		jt[tn] = j.storages.ListBackups(tn)
+	}
+
+	return jt
+}
+
 func (j *job) SetDumpObjectDelivered(ofs string) {
 	dumpObj := j.dumpedObjects[ofs]
 	dumpObj.Delivered = true

--- a/modules/backup/psql/psql.go
+++ b/modules/backup/psql/psql.go
@@ -205,6 +205,17 @@ func (j *job) GetDumpObjects() map[string]interfaces.DumpObject {
 	return j.dumpedObjects
 }
 
+func (j *job) ListBackups() interfaces.JobTargets {
+	jt := make(interfaces.JobTargets)
+
+	for tn := range j.targets {
+		jt[tn] = make(interfaces.TargetsOnStorages)
+		jt[tn] = j.storages.ListBackups(tn)
+	}
+
+	return jt
+}
+
 func (j *job) SetDumpObjectDelivered(ofs string) {
 	dumpObj := j.dumpedObjects[ofs]
 	dumpObj.Delivered = true

--- a/modules/backup/psql_basebackup/psql_basebackup.go
+++ b/modules/backup/psql_basebackup/psql_basebackup.go
@@ -166,6 +166,17 @@ func (j *job) GetDumpObjects() map[string]interfaces.DumpObject {
 	return j.dumpedObjects
 }
 
+func (j *job) ListBackups() interfaces.JobTargets {
+	jt := make(interfaces.JobTargets)
+
+	for tn := range j.targets {
+		jt[tn] = make(interfaces.TargetsOnStorages)
+		jt[tn] = j.storages.ListBackups(tn)
+	}
+
+	return jt
+}
+
 func (j *job) SetDumpObjectDelivered(ofs string) {
 	dumpObj := j.dumpedObjects[ofs]
 	dumpObj.Delivered = true

--- a/modules/backup/redis/redis.go
+++ b/modules/backup/redis/redis.go
@@ -138,6 +138,17 @@ func (j *job) GetDumpObjects() map[string]interfaces.DumpObject {
 	return j.dumpedObjects
 }
 
+func (j *job) ListBackups() interfaces.JobTargets {
+	jt := make(interfaces.JobTargets)
+
+	for tn := range j.targets {
+		jt[tn] = make(interfaces.TargetsOnStorages)
+		jt[tn] = j.storages.ListBackups(tn)
+	}
+
+	return jt
+}
+
 func (j *job) SetDumpObjectDelivered(ofs string) {
 	dumpObj := j.dumpedObjects[ofs]
 	dumpObj.Delivered = true

--- a/modules/cmd_handler/list_backups/list_backups.go
+++ b/modules/cmd_handler/list_backups/list_backups.go
@@ -1,0 +1,168 @@
+package list_backups
+
+import (
+	"fmt"
+	"github.com/fatih/color"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/nixys/nxs-backup/interfaces"
+	"github.com/nixys/nxs-backup/misc"
+)
+
+type Opts struct {
+	JobName  string
+	InitErr  error
+	Done     chan error
+	FileJobs interfaces.Jobs
+	DBJobs   interfaces.Jobs
+	ExtJobs  interfaces.Jobs
+	Jobs     map[string]interfaces.Job
+}
+
+type listBackups struct {
+	jobName  string
+	initErr  error
+	done     chan error
+	fileJobs interfaces.Jobs
+	dbJobs   interfaces.Jobs
+	extJobs  interfaces.Jobs
+	jobs     map[string]interfaces.Job
+}
+
+type treeElement struct {
+	name     string
+	children []treeElement
+}
+
+var (
+	bold       = color.New(color.Bold)
+	italic     = color.New(color.Italic)
+	italicBold = color.New(color.Italic, color.Bold)
+)
+
+func Init(o Opts) *listBackups {
+	return &listBackups{
+		jobName:  o.JobName,
+		initErr:  o.InitErr,
+		done:     o.Done,
+		fileJobs: o.FileJobs,
+		dbJobs:   o.DBJobs,
+		extJobs:  o.ExtJobs,
+		jobs:     o.Jobs,
+	}
+}
+
+func (lb *listBackups) Run() {
+	var err error
+	errs := new(multierror.Error)
+
+	defer func() {
+		lb.done <- err
+	}()
+
+	if lb.initErr != nil {
+		color.HiRed("[WARNING!] Backup plan initialised with errors:")
+		fmt.Println(lb.initErr)
+	}
+
+	if lb.jobName == "external" || lb.jobName == "all" {
+		err := printBackups("External", lb.extJobs)
+		errs = multierror.Append(err, errs)
+	}
+	if lb.jobName == "databases" || lb.jobName == "all" {
+		err := printBackups("Database", lb.dbJobs)
+		errs = multierror.Append(err, errs)
+	}
+	if lb.jobName == "files" || lb.jobName == "all" {
+		err := printBackups("File", lb.fileJobs)
+		errs = multierror.Append(err, errs)
+	}
+	if job, ok := lb.jobs[lb.jobName]; ok {
+		err := printBackups("", interfaces.Jobs{job})
+		errs = multierror.Append(err, errs)
+	}
+	if errs.Len() > 0 {
+		color.HiRed("[WARNING!] Execution finished with errors.")
+		err = misc.ErrExecution
+	}
+}
+
+func printBackups(bType string, jobs interfaces.Jobs) (err error) {
+	var backupsTree []treeElement
+
+	if len(bType) > 0 && len(jobs) > 0 {
+		bold.Printf("%s backup jobs\n", bType)
+	}
+
+	for _, job := range jobs {
+		var jobTargets []treeElement
+		jt := job.ListBackups()
+		for tName, tOnSt := range jt {
+			jobTargetSts := make([]treeElement, 0, len(tOnSt))
+			for st, tFiles := range tOnSt {
+				jobTargetStFiles := make([]treeElement, 0, len(tFiles.List))
+				if tFiles.ListErr == nil {
+					for _, f := range tFiles.List {
+						jobTargetStFiles = append(jobTargetStFiles, treeElement{
+							name: f,
+						})
+					}
+				} else {
+					jobTargetStFiles = append(jobTargetStFiles, treeElement{
+						name: fmt.Sprintf("Failed to get files from storage. Err: `%v`", tFiles.ListErr),
+					})
+					err = misc.ErrExecution
+				}
+
+				jobTargetSts = append(jobTargetSts, treeElement{
+					name:     st,
+					children: jobTargetStFiles,
+				})
+			}
+			jobTargets = append(jobTargets, treeElement{
+				name:     tName,
+				children: jobTargetSts,
+			})
+		}
+		backupsTree = append(backupsTree, treeElement{
+			name:     job.GetName(),
+			children: jobTargets,
+		})
+	}
+
+	if len(bType) == 0 && len(jobs) == 1 {
+		italicBold.Printf("%s backup job\n", jobs[0].GetName())
+		printTree(backupsTree[0].children, "", 1)
+	} else {
+		printTree(backupsTree, "", 0)
+	}
+
+	return
+}
+
+func printTree(elements []treeElement, prefix string, lvl int) {
+	for i, e := range elements {
+		if i == len(elements)-1 {
+			fmt.Print(prefix + "└── ")
+			printlnWithLevel(lvl, e.name)
+			printTree(e.children, prefix+"    ", lvl+1)
+		} else {
+			fmt.Print(prefix + "├── ")
+			printlnWithLevel(lvl, e.name)
+			printTree(e.children, prefix+"│   ", lvl+1)
+		}
+	}
+}
+
+func printlnWithLevel(level int, msg string) {
+	switch level {
+	case 0:
+		italicBold.Println(msg)
+	case 1:
+		bold.Println(msg)
+	case 2:
+		italic.Println(msg)
+	default:
+		fmt.Println(msg)
+	}
+}


### PR DESCRIPTION
Changes:
- Added backup listing feature on storage and job interfaces.
- Implemented this feature in NFS, SMB, SFTP, local and webdav storage modules.
- Applied this functionality in file, database, and external jobs.
- Initiated use of backup listing in cmd handler.
- Introduced new error ErrExecution to denote execution errors.
- Improved sorting functionality in local, SMB and NFS storage's DeleteOldBackups methods.
- Renamed NFS module file to nfs_v3.go for clarity.
- Fixed file path configuration issue in local and webdav storage.
- Fixed delete old backups functionality for NFS storage.
- Tidied up minor formatting and variable naming issues.