### PR TITLE
fix(#79): Update timestamp handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         go-version: '1.22.6'
 
     - name: Set version
-      run: V=${{ github.ref_name }} && VT="${V#v}" && sed "s@APP_VERSION@$VT@" misc/version.go.in > misc/version.go
+      run: V="3-test-build-${{ github.event.pull_request.head.sha }}" && sed "s@APP_VERSION@$V@" misc/version.go.in > misc/version.go
 
     - name: Build
       run: GOOS=linux GOARCH=${{ matrix.TARGET }} CGO_ENABLED=0 go build -ldflags="-s -w" -v -o nxs-backup-${{ matrix.TARGET }}

--- a/modules/storage/common.go
+++ b/modules/storage/common.go
@@ -61,7 +61,7 @@ func GetRetention(p retentionPeriod, r Retention) (retentionCount int, retention
 			return
 		}
 		retentionCount = r.Months
-		retentionDate = curDate.AddDate(0, -r.Months, +1)
+		retentionDate = curDate.AddDate(0, -r.Months, 1)
 	}
 	return
 }

--- a/modules/storage/ftp/ftp.go
+++ b/modules/storage/ftp/ftp.go
@@ -207,6 +207,10 @@ func (f *FTP) deleteDescBackup(logCh chan logger.LogRecord, job, ofsPart string,
 		} else {
 			i := 0
 			for _, file := range fptFiles {
+				if file.Time.Location() != retentionDate.Location() {
+					retentionDate = retentionDate.In(file.Time.Location())
+				}
+
 				if file.Time.Before(retentionDate) {
 					fptFiles[i] = file
 					i++

--- a/modules/storage/local/local.go
+++ b/modules/storage/local/local.go
@@ -242,6 +242,10 @@ func (l *Local) deleteDescBackup(logCh chan logger.LogRecord, jobName, ofsPart s
 			i := 0
 			for _, file := range lFiles {
 				fileInfo, _ := file.Info()
+				if fileInfo.ModTime().Location() != retentionDate.Location() {
+					retentionDate = retentionDate.In(fileInfo.ModTime().Location())
+				}
+
 				if fileInfo.ModTime().Before(retentionDate) {
 					lFiles[i] = file
 					i++

--- a/modules/storage/nfs/nfs_v3.go
+++ b/modules/storage/nfs/nfs_v3.go
@@ -214,6 +214,10 @@ func (n *NFS) deleteDescBackup(logCh chan logger.LogRecord, jobName, ofsPart str
 		} else {
 			i := 0
 			for _, file := range nfsFiles {
+				if file.ModTime().Location() != retentionDate.Location() {
+					retentionDate = retentionDate.In(file.ModTime().Location())
+				}
+
 				if file.ModTime().Before(retentionDate) {
 					nfsFiles[i] = file
 					i++

--- a/modules/storage/s3/s3.go
+++ b/modules/storage/s3/s3.go
@@ -190,16 +190,20 @@ func (s *S3) DeleteOldBackups(logCh chan logger.LogRecord, ofs string, job inter
 				}
 			}
 		} else {
+			if object.LastModified.Location() != curDate.Location() {
+				curDate = curDate.In(object.LastModified.Location())
+			}
+
 			if strings.Contains(object.Key, Daily.String()) && s.Retention.Days > 0 {
-				if s.Retention.UseCount || object.LastModified.Before(curDate.AddDate(0, 0, -s.Retention.Days)) {
+				if s.Retention.UseCount || object.LastModified.Before(curDate.AddDate(0, 0, -s.Retention.Days+1)) {
 					filesList["daily"] = append(filesList["daily"], object)
 				}
 			} else if strings.Contains(object.Key, Weekly.String()) && s.Retention.Weeks > 0 && misc.GetDateTimeNow("dow") == misc.WeeklyBackupDay {
-				if s.Retention.UseCount || object.LastModified.Before(curDate.AddDate(0, 0, -s.Retention.Weeks*7)) {
+				if s.Retention.UseCount || object.LastModified.Before(curDate.AddDate(0, 0, -s.Retention.Weeks*7+1)) {
 					filesList["weekly"] = append(filesList["weekly"], object)
 				}
 			} else if strings.Contains(object.Key, Monthly.String()) && s.Retention.Weeks > 0 && misc.GetDateTimeNow("dom") == misc.MonthlyBackupDay {
-				if s.Retention.UseCount || object.LastModified.Before(curDate.AddDate(0, -s.Retention.Months, 0)) {
+				if s.Retention.UseCount || object.LastModified.Before(curDate.AddDate(0, -s.Retention.Months, 1)) {
 					filesList["monthly"] = append(filesList["monthly"], object)
 				}
 			}

--- a/modules/storage/sftp/sftp.go
+++ b/modules/storage/sftp/sftp.go
@@ -278,6 +278,10 @@ func (s *SFTP) deleteDescBackup(logCh chan logger.LogRecord, jobName, ofsPart st
 		} else {
 			i := 0
 			for _, file := range files {
+				if file.ModTime().Location() != retentionDate.Location() {
+					retentionDate = retentionDate.In(file.ModTime().Location())
+				}
+
 				if file.ModTime().Before(retentionDate) {
 					files[i] = file
 					i++

--- a/modules/storage/smb/smb.go
+++ b/modules/storage/smb/smb.go
@@ -248,6 +248,10 @@ func (s *SMB) deleteDescBackup(logCh chan logger.LogRecord, jobName, ofsPart str
 		} else {
 			i := 0
 			for _, file := range smbFiles {
+				if file.ModTime().Location() != retentionDate.Location() {
+					retentionDate = retentionDate.In(file.ModTime().Location())
+				}
+
 				if file.ModTime().Before(retentionDate) {
 					smbFiles[i] = file
 					i++

--- a/modules/storage/webdav/webdav.go
+++ b/modules/storage/webdav/webdav.go
@@ -190,6 +190,10 @@ func (wd *WebDav) deleteDescBackup(logCh chan logger.LogRecord, jobName, ofsPart
 		} else {
 			i := 0
 			for _, file := range wdFiles {
+				if file.ModTime().Location() != retentionDate.Location() {
+					retentionDate = retentionDate.In(file.ModTime().Location())
+				}
+
 				if file.ModTime().Before(retentionDate) {
 					wdFiles[i] = file
 					i++


### PR DESCRIPTION
Changes:
- Adjust timestamps to match the retention date's timezone before comparison in SMB, S3, SFTP, NFS, WebDAV, local, and FTP storage modules.