### PR TITLE
feat: Set request host for WebHook.

### DIFF
--- a/modules/notifier/webhooker/webhooker.go
+++ b/modules/notifier/webhooker/webhooker.go
@@ -69,8 +69,15 @@ func (wh *webhook) Send(log *logrus.Logger, n logger.LogRecord) {
 		log.Errorf("Can't create webhook request: %v", err)
 		return
 	}
+	req.Header.Add("Content-Type", "application/json")
 
 	for k, v := range wh.opts.ExtraHeaders {
+		if k == "Content-Type" {
+			continue
+		}
+		if k == "Host" {
+			req.Host = v
+		}
 		req.Header.Add(k, v)
 	}
 


### PR DESCRIPTION
Changes:
- Added a default "Content-Type: application/json" header to webhook requests.
- Ensured "Content-Type" and "Host" headers are handled correctly in ExtraHeaders.
- Set the request host according to the header.