### PR TITLE
feat: add defaults_file option for xtrabackup/mariadb-backup

### DIFF
--- a/.deploy/on-premise/conf.d/mysql_xtrabackup.conf
+++ b/.deploy/on-premise/conf.d/mysql_xtrabackup.conf
@@ -13,7 +13,12 @@ sources:
     excludes:
       - bd_name.table_to_exclude
     gzip: true
-    db_extra_keys: --datadir=/path/to/mysql/data
+    # Path to the MySQL server config (my.cnf). Passed to xtrabackup/mariadb-backup
+    # as `--defaults-file` (placed first on the command line, as required) so the
+    # tool can locate `datadir` and other server settings when they are not in a
+    # default location.
+    defaults_file: /etc/mysql/my.cnf
+    db_extra_keys: --parallel=4 --lock-ddl-per-table
     prepare_xtrabackup: true
 storages_options:
   - storage_name: local

--- a/ctx/conf.go
+++ b/ctx/conf.go
@@ -98,6 +98,7 @@ type sourceConf struct {
 	ExcludeDBs         []string          `conf:"exclude_dbs"`
 	ExcludeCollections []string          `conf:"exclude_collections"`
 	ExtraKeys          string            `conf:"db_extra_keys"`
+	DefaultsFile       string            `conf:"defaults_file"`
 	Gzip               *bool             `conf:"gzip" conf_extraopts:"default=false"`
 	IsSlave            bool              `conf:"is_slave" conf_extraopts:"default=false"`
 	SaveAbsPath        bool              `conf:"save_abs_path" conf_extraopts:"default=true"`

--- a/ctx/jobs_init.go
+++ b/ctx/jobs_init.go
@@ -229,13 +229,14 @@ func jobsInit(o jobsOpts) ([]interfaces.Job, error) {
 						SSLCert:  src.Connect.SSLCert,
 						SSLKey:   src.Connect.SSLKey,
 					},
-					Name:      src.Name,
-					TargetDBs: src.TargetDBs,
-					Excludes:  src.Excludes,
-					IsSlave:   src.IsSlave,
-					Prepare:   src.PrepareXtrabackup,
-					ExtraKeys: getExtraKeys(src.ExtraKeys),
-					Gzip:      isGzip(src.Gzip, j.Gzip),
+					Name:         src.Name,
+					TargetDBs:    src.TargetDBs,
+					Excludes:     src.Excludes,
+					IsSlave:      src.IsSlave,
+					Prepare:      src.PrepareXtrabackup,
+					DefaultsFile: src.DefaultsFile,
+					ExtraKeys:    getExtraKeys(src.ExtraKeys),
+					Gzip:         isGzip(src.Gzip, j.Gzip),
 				})
 			}
 

--- a/modules/backup/mysql_physical/mysql_physical.go
+++ b/modules/backup/mysql_physical/mysql_physical.go
@@ -42,6 +42,7 @@ type job struct {
 type target struct {
 	extraKeys       []string
 	authFile        *ini.File
+	defaultsFile    string
 	ignoreDatabases string
 	gzip            bool
 	isSlave         bool
@@ -67,6 +68,7 @@ type SourceParams struct {
 	TargetDBs     []string
 	Excludes      []string
 	ExtraKeys     []string
+	DefaultsFile  string
 	Gzip          bool
 	IsSlave       bool
 	Prepare       bool
@@ -131,6 +133,7 @@ func Init(jp JobParams) (interfaces.Job, error) {
 
 		j.targets[src.Name] = target{
 			authFile:        authFile,
+			defaultsFile:    src.DefaultsFile,
 			ignoreDatabases: ignoreDBs,
 			extraKeys:       src.ExtraKeys,
 			gzip:            src.Gzip,
@@ -296,7 +299,13 @@ func (j *job) createTmpBackup(logCh chan logger.LogRecord, tmpBackupFile, tgtNam
 		}
 	}()
 
-	// define commands args with auth options
+	// define commands args with defaults options.
+	// `--defaults-file` (if set) and `--defaults-extra-file` must be the first
+	// options on the command line, otherwise xtrabackup/mariadb-backup refuses
+	// with "--defaults-file must be specified first on the command line".
+	if target.defaultsFile != "" {
+		backupArgs = append(backupArgs, "--defaults-file="+target.defaultsFile)
+	}
 	backupArgs = append(backupArgs, "--defaults-extra-file="+authFile)
 	prepareArgs = backupArgs
 	// add backup options


### PR DESCRIPTION
Add `defaults_file` config key passed to xtrabackup/mariadb-backup as `--defaults-file`, placed first on the command line (before the internal `--defaults-extra-file` with credentials) as required by the MySQL option-file parser. This lets the tool locate datadir and other server settings when the server config is not in a default location.