### PR TITLE
fix(redis): pass password to Redis during connectivity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # nxs-backup
 
-[![Telegram News][tg-news-badge]][tg-news-url] [![Telegram Chat][tg-chat-badge]][tg-chat-url]
-
-![nxs-backup](https://github.com/nixys/nxs-backup/assets/28505813/20d0da34-eb6e-4ae4-a5c9-24845407400f)
+> **⚠️ Форк.** Это форк [nixys/nxs-backup](https://github.com/nixys/nxs-backup), созданный 2026-08-03.
+> Пока используется только для личных нужд, изменения вносятся понемногу и без гарантий совместимости с оригиналом.
 
 nxs-backup is a tool for creating and delivery backups, rotating it locally and on remote storages, compatible with
 GNU/Linux distributions.
@@ -143,8 +142,3 @@ For news and discussions subscribe the channels:
 ## License
 
 nxs-backup is released under the [Apache-2.0 license](LICENSE).
-
-[tg-news-badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fnxs_backup
-[tg-chat-badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fnxs_backup_chat
-[tg-news-url]: https://t.me/nxs_backup
-[tg-chat-url]: https://t.me/nxs_backup_chat

--- a/ds/redis_connect/redis_connect.go
+++ b/ds/redis_connect/redis_connect.go
@@ -42,11 +42,16 @@ func GetConnectAndDSN(params Params) (rdb *redis.Client, dsn string, err error) 
 	if err != nil {
 		return
 	}
+	opt.Password = params.Passwd
 	rdb = redis.NewClient(opt)
 
 	err = rdb.Ping(context.Background()).Err()
 
-	// this is not a bug, this is strange behavior of redis-cli uri usage
+	// redis-cli treats a single userinfo segment (no colon) as a legacy,
+	// version-agnostic `AUTH <password>`, whereas a `user:password` segment
+	// makes it send a 2-arg `AUTH user password` that pre-6.0 Redis (no ACL
+	// support) rejects. So the DSN below intentionally differs from how
+	// opt.Password above is set for the go-redis client.
 	if params.Passwd != "" {
 		connUrl.User = url.User(params.Passwd)
 	}


### PR DESCRIPTION
## Summary
- The Redis job's `GetConnectAndDSN` pinged the server to validate connectivity *before* the password was added to the connection URL, so the go-redis client used for that check never authenticated. Any redis job with a password configured failed at init with `NOAUTH Authentication required`, even though the password was correct.
- `opt.Password` is now set explicitly before the `Ping()` call.
- The DSN passed to `redis-cli` for the actual dump keeps its pre-existing single-segment userinfo format (`redis://password@host`), since that's the form `redis-cli` treats as a legacy 1-arg `AUTH <password>` — compatible with pre-6.0 (non-ACL) Redis. Using `user:password` instead would send a 2-arg `AUTH` that older Redis rejects.

## Test plan
- [x] Built the binary in a local Docker image and ran it against a Redis 7 container with `requirepass` set.
- [x] Confirmed on `main` (pre-fix): job init fails with `Redis connect error: NOAUTH Authentication required`.
- [x] Confirmed with this fix: job initializes and produces a valid `.rdb.gz` dump.